### PR TITLE
Troubleshoot npm expo start error

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,6 +35,8 @@
       },
       "package": "com.mirae.safeplaces",
       "permissions": [
+        "android.permission.CAMERA",
+        "android.permission.RECORD_AUDIO",
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION",
         "RECEIVE_BOOT_COMPLETED",
@@ -64,7 +66,9 @@
             "./assets/notification-sound.wav"
           ]
         }
-      ]
+      ],
+      "@livekit/react-native-expo-plugin",
+      "@config-plugins/react-native-webrtc"
     ],
     "extra": {
       "eas": {

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,9 @@
 import { registerRootComponent } from 'expo';
 
 import App from './App';
+import { registerGlobals } from '@livekit/react-native';
 
+registerGlobals();
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,11 +37,12 @@
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.13.1",
         "react-native-svg": "15.11.2",
-        "react-native-url-polyfill": "^2.0.0",
-        "react-native-webrtc": "^124.0.6"
+        "react-native-url-polyfill": "^2.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@config-plugins/react-native-webrtc": "^12.0.0",
+        "@livekit/react-native-expo-plugin": "^1.0.1",
         "@react-native-community/cli": "^20.0.0",
         "@types/base64-arraybuffer": "^0.1.0",
         "@types/react": "~19.0.10",
@@ -1528,6 +1529,16 @@
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@config-plugins/react-native-webrtc": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@config-plugins/react-native-webrtc/-/react-native-webrtc-12.0.0.tgz",
+      "integrity": "sha512-EIYR+ArIOFBz8cEHSdPjxqFPhaN+nNeoPnI6iVStctYKZdl6AEgmXq6Qfpds6qyin1W4JP7wq2jJh32OsRfwxg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "^53"
+      }
+    },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -2829,6 +2840,19 @@
       "peerDependencies": {
         "@livekit/react-native-webrtc": "^137.0.1",
         "livekit-client": "^2.15.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native-expo-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native-expo-plugin/-/react-native-expo-plugin-1.0.1.tgz",
+      "integrity": "sha512-CSPjjzgDDlBH1ZyFyaw7/FW2Ql1S51eUkIxv/vjGwVshn+lUD6eQ9VgfUh7ha84itvjXi9X87FvP0XWKn9CiFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@livekit/react-native": "^2.1.0",
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -10188,43 +10212,6 @@
       "peerDependencies": {
         "react-native": "*"
       }
-    },
-    "node_modules/react-native-webrtc": {
-      "version": "124.0.6",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.6.tgz",
-      "integrity": "sha512-5GviOGK19vujT7sGvSYdZE+bBlh0KC9g1JLharzajpCDVrNdCSpYxveOJUINSRevLsmL12FgNJJgnTjFKn7Aqw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "1.5.1",
-        "debug": "4.3.4",
-        "event-target-shim": "6.0.2"
-      },
-      "peerDependencies": {
-        "react-native": ">=0.60.0"
-      }
-    },
-    "node_modules/react-native-webrtc/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-native-webrtc/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
       "version": "0.79.5",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,12 @@
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.1",
     "react-native-svg": "15.11.2",
-    "react-native-url-polyfill": "^2.0.0",
-    "react-native-webrtc": "^124.0.6"
+    "react-native-url-polyfill": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@config-plugins/react-native-webrtc": "^12.0.0",
+    "@livekit/react-native-expo-plugin": "^1.0.1",
     "@react-native-community/cli": "^20.0.0",
     "@types/base64-arraybuffer": "^0.1.0",
     "@types/react": "~19.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,6 +783,11 @@
   resolved "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz"
   integrity sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==
 
+"@config-plugins/react-native-webrtc@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@config-plugins/react-native-webrtc/-/react-native-webrtc-12.0.0.tgz"
+  integrity sha512-EIYR+ArIOFBz8cEHSdPjxqFPhaN+nNeoPnI6iVStctYKZdl6AEgmXq6Qfpds6qyin1W4JP7wq2jJh32OsRfwxg==
+
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
   resolved "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz"
@@ -1287,6 +1292,11 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
+"@livekit/react-native-expo-plugin@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@livekit/react-native-expo-plugin/-/react-native-expo-plugin-1.0.1.tgz"
+  integrity sha512-CSPjjzgDDlBH1ZyFyaw7/FW2Ql1S51eUkIxv/vjGwVshn+lUD6eQ9VgfUh7ha84itvjXi9X87FvP0XWKn9CiFQ==
+
 "@livekit/react-native-webrtc@^137.0.1":
   version "137.0.1"
   resolved "https://registry.npmjs.org/@livekit/react-native-webrtc/-/react-native-webrtc-137.0.1.tgz"
@@ -1296,7 +1306,7 @@
     debug "4.3.4"
     event-target-shim "6.0.2"
 
-"@livekit/react-native@^2.9.1":
+"@livekit/react-native@^2.1.0", "@livekit/react-native@^2.9.1":
   version "2.9.1"
   resolved "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.9.1.tgz"
   integrity sha512-oN1aWQeAuo3NhhrQRCI/V9upi8PhRQRFyZHBqnU/AlxYFyTKWKGmtVJtJWkGW+zNUF3lEF+nZMnpIHft9aJdqQ==
@@ -3378,7 +3388,7 @@ expo-status-bar@~2.2.3:
     react-native-edge-to-edge "1.6.0"
     react-native-is-edge-to-edge "^1.1.6"
 
-expo@*, expo@>=52.0.0, expo@~53.0.20:
+expo@*, expo@^53, expo@>=52.0.0, expo@~53.0.20:
   version "53.0.20"
   resolved "https://registry.npmjs.org/expo/-/expo-53.0.20.tgz"
   integrity sha512-Nh+HIywVy9KxT/LtH08QcXqrxtUOA9BZhsXn3KCsAYA+kNb80M8VKN8/jfQF+I6CgeKyFKJoPNsWgI0y0VBGrA==
@@ -3537,11 +3547,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -4396,36 +4401,6 @@ lighthouse-logger@^1.0.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
-lightningcss-darwin-arm64@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz"
-  integrity sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==
-
-lightningcss-darwin-x64@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz"
-  integrity sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==
-
-lightningcss-freebsd-x64@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz"
-  integrity sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==
-
-lightningcss-linux-arm-gnueabihf@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz"
-  integrity sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==
-
-lightningcss-linux-arm64-gnu@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz"
-  integrity sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==
-
-lightningcss-linux-arm64-musl@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz"
-  integrity sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==
-
 lightningcss-linux-x64-gnu@1.27.0:
   version "1.27.0"
   resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz"
@@ -4435,16 +4410,6 @@ lightningcss-linux-x64-musl@1.27.0:
   version "1.27.0"
   resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz"
   integrity sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==
-
-lightningcss-win32-arm64-msvc@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz"
-  integrity sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==
-
-lightningcss-win32-x64-msvc@1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz"
-  integrity sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==
 
 lightningcss@~1.27.0:
   version "1.27.0"
@@ -5548,15 +5513,6 @@ react-native-url-polyfill@^2.0.0:
   integrity sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
-
-react-native-webrtc@^124.0.6:
-  version "124.0.6"
-  resolved "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.6.tgz"
-  integrity sha512-5GviOGK19vujT7sGvSYdZE+bBlh0KC9g1JLharzajpCDVrNdCSpYxveOJUINSRevLsmL12FgNJJgnTjFKn7Aqw==
-  dependencies:
-    base64-js "1.5.1"
-    debug "4.3.4"
-    event-target-shim "6.0.2"
 
 react-native@*, "react-native@^0.0.0-0 || >=0.65 <1.0", "react-native@>= 0.50.0", "react-native@>= 0.64.3", react-native@>=0.59, react-native@>=0.60.0, react-native@0.79.5:
   version "0.79.5"


### PR DESCRIPTION
Configure Expo project for LiveKit WebRTC to resolve "WebRTC native module not found" error.

The error occurred because WebRTC is a native module not bundled in Expo Go. This PR adds necessary camera/microphone permissions and LiveKit/WebRTC plugins to `app.json`, registers globals in `index.ts`, and updates dependencies to support LiveKit's WebRTC implementation in a development build.

---
<a href="https://cursor.com/background-agent?bcId=bc-3616e079-736a-417e-9f02-187931246240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3616e079-736a-417e-9f02-187931246240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

