### PR TITLE
Fix user search to query database and respect settings

### DIFF
--- a/services/profileService.ts
+++ b/services/profileService.ts
@@ -296,7 +296,7 @@ class ProfileService {
         email,
         created_at,
         updated_at,
-        profiles(
+        profiles!inner(
           username,
           show_profile,
           appear_in_search,
@@ -328,7 +328,7 @@ class ProfileService {
       }
 
       if (blockedIds.length > 0) {
-        const blockedList = `(${blockedIds.join(",")})`
+        const blockedList = `(${blockedIds.map((id) => `"${id}"`).join(",")})`
         usersByNameOrBio = usersByNameOrBio.not("id", "in", blockedList)
         usersByUsername = usersByUsername.not("id", "in", blockedList)
       }
@@ -346,8 +346,8 @@ class ProfileService {
       }
 
       const combined: any[] = [
-        ...(nameBioResult.data || []),
-        ...(usernameResult.data || []),
+        ...((nameBioResult.data as any[]) || []),
+        ...((usernameResult.data as any[]) || []),
       ]
 
       // Dedupe by user id

--- a/supabase-incremental-updates.sql
+++ b/supabase-incremental-updates.sql
@@ -69,6 +69,19 @@ BEGIN
   END IF;
 END $$;
 
+-- Allow selecting public profiles for discovery (respect settings)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policy 
+    WHERE polname = 'Users can view public profiles' 
+      AND tablename = 'profiles'
+  ) THEN
+    CREATE POLICY "Users can view public profiles" ON profiles
+      FOR SELECT USING (show_profile IS TRUE AND appear_in_search IS TRUE);
+  END IF;
+END $$;
+
 -- Indexes to speed up joins and username lookups
 CREATE INDEX IF NOT EXISTS idx_profiles_id ON profiles(id);
 CREATE INDEX IF NOT EXISTS idx_profiles_username ON profiles(username);


### PR DESCRIPTION
Fix user search to correctly return results from the database while respecting user privacy settings.

The previous search implementation was failing to return results due to an incorrect Supabase query that didn't properly leverage Row Level Security (RLS) with joins, and a missing RLS policy. This PR updates the query to use an inner join on `profiles` and adds an RLS policy to allow selecting profiles only when `show_profile` and `appear_in_search` are true, ensuring search results are accurate and respect user privacy.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e4d960-b2ca-4335-8609-22f3196ea231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34e4d960-b2ca-4335-8609-22f3196ea231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

