### PR TITLE
Fix navigation type error for auth screen

### DIFF
--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -56,8 +56,8 @@ export default function LoadingScreen({ navigation }: AuthStackScreenProps<"Load
           // Navigate to the main app through the root navigator
           navigation.getParent()?.navigate("Main")
         } else {
-          // If user is not authenticated, navigate to auth screen
-          navigation.navigate("Auth")
+          // If user is not authenticated, navigate to sign-in screen within the Auth stack
+          navigation.navigate("SignIn")
         }
       }
     };


### PR DESCRIPTION
Fixes type error in LoadingScreen by navigating to 'SignIn' within AuthStack instead of 'Auth' in the root navigator.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d4a0db7-50b8-4ea7-8dc7-cfc68e59eafe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d4a0db7-50b8-4ea7-8dc7-cfc68e59eafe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

