### PR TITLE
Restore map to interactive marker-only state

### DIFF
--- a/src/screens/BusinessDetailScreen.tsx
+++ b/src/screens/BusinessDetailScreen.tsx
@@ -297,13 +297,24 @@ export default function BusinessDetailsScreen({ route, navigation }: BusinessDet
                   latitudeDelta: 0.01,
                   longitudeDelta: 0.01,
                 }}
-                liteMode={true}
+                showsUserLocation={true}
+                showsMyLocationButton={true}
+                showsCompass={true}
+                showsScale={true}
+                zoomEnabled={true}
+                scrollEnabled={true}
+                rotateEnabled={true}
+                pitchEnabled={true}
+                toolbarEnabled={true}
+                mapPadding={{ top: 0, right: 0, bottom: 0, left: 0 }}
               >
                 <Marker
                   coordinate={{ latitude: business.latitude, longitude: business.longitude }}
                   title={business.name}
                   description={business.address}
                   onPress={handleDirections}
+                  tracksViewChanges={false}
+                  draggable={false}
                 />
               </MapView>
             </View>
@@ -540,10 +551,12 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: "hidden",
     marginBottom: 25,
+    zIndex: 1,
   },
   map: {
     width: "100%",
     height: "100%",
+    zIndex: 1,
   },
   reviewsSection: {
     marginBottom: 25,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -262,8 +262,15 @@ export default function HomeScreen({ navigation }: HomeScreenProps) {
               longitudeDelta: 0.0421,
             }}
             showsUserLocation={true}
-            showsMyLocationButton={false}
-            liteMode={true}
+            showsMyLocationButton={true}
+            showsCompass={true}
+            showsScale={true}
+            zoomEnabled={true}
+            scrollEnabled={true}
+            rotateEnabled={true}
+            pitchEnabled={true}
+            toolbarEnabled={true}
+            mapPadding={{ top: 0, right: 0, bottom: 0, left: 0 }}
           >
             {initialMarkers.map((business) => (
               <Marker
@@ -276,6 +283,8 @@ export default function HomeScreen({ navigation }: HomeScreenProps) {
                 title={business.name}
                 description={business.address || business.description}
                 onPress={() => navigation.navigate("BusinessDetails", { business })}
+                tracksViewChanges={false}
+                draggable={false}
               />
             ))}
           </MapView>
@@ -402,12 +411,15 @@ const styles = StyleSheet.create({
   mapContainer: {
     flex: 1,
     flexGrow: 1,
-    height: "98%",
+    height: "100%",
     position: "relative",
+    zIndex: 1,
   },
   map: {
     flex: 1,
     height: "100%",
+    width: "100%",
+    zIndex: 1,
   },
   legend: {
     position: "absolute",
@@ -420,6 +432,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
+    zIndex: 10,
   },
   legendTitle: {
     fontSize: 14,


### PR DESCRIPTION
Restore map interactivity by removing `liteMode` and enabling full map features.

The map was rendered as a static image due to `liteMode={true}`, which prevented any user interaction like zooming, panning, or marker clicks. This PR re-enables all standard map gestures and controls, and ensures markers are properly configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac422e9d-9d3a-4646-8958-8fec761a8340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac422e9d-9d3a-4646-8958-8fec761a8340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

