### PR TITLE
Fix business details disappearing after click

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -216,6 +216,11 @@ export default function HomeScreen({ navigation, route }: HomeScreenProps) {
     <TouchableOpacity
       style={styles.businessCard}
       onPress={() => {
+        // In list view, go to details; in map view, focus the marker
+        if (!showMap) {
+          navigation.navigate("BusinessDetails", { business: item })
+          return
+        }
         if (typeof item.latitude === 'number' && typeof item.longitude === 'number') {
           setSelectedBusinessId(item.id)
           setShowMap(true)
@@ -227,6 +232,8 @@ export default function HomeScreen({ navigation, route }: HomeScreenProps) {
               longitudeDelta: 0.02,
             }, 500)
           }
+        } else {
+          navigation.navigate("BusinessDetails", { business: item })
         }
       }}
     >


### PR DESCRIPTION
Re-enable navigation to Business Details when tapping a business card in the list view.

Previously, tapping a business card in the list view only focused the map, preventing users from seeing business details. This change ensures that when `showMap` is false, tapping a business card navigates to the `BusinessDetails` screen. It also handles cases where map view is active but coordinates are missing, ensuring navigation to details.

---
<a href="https://cursor.com/background-agent?bcId=bc-190acb5c-0302-42c3-b9cd-89273f01b3a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-190acb5c-0302-42c3-b9cd-89273f01b3a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

